### PR TITLE
on every build a new .pot file is in the directory po/

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -16,17 +16,19 @@ set(POT_FILE ${DOMAIN}.pot)
 file(GLOB PO_FILES *.po)
 
 add_custom_target(${POT_FILE} ALL
-                  COMMENT "Generating translation template"
-                  COMMAND ${INTLTOOL_EXTRACT} --update --type=gettext/ini
-                          --srcdir=${CMAKE_SOURCE_DIR} ${DESKTOP_FILE_IN_IN}
-                  COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} -o ${POT_FILE}
-                          --from-code=UTF-8
-                          --c++ --qt --add-comments=TRANSLATORS
-                          --keyword=tr --keyword=tr:1,2 --keyword=N_
-                          --package-name='${GALLERY}'
-                          --copyright-holder='Canonical Ltd.'
-                          -D ${CMAKE_SOURCE_DIR} ${I18N_SRC_FILES}
-                          -D ${CMAKE_CURRENT_BINARY_DIR} ${DESKTOP_FILE_IN_IN_H})
+    COMMENT "Generating translation template"
+    COMMAND ${INTLTOOL_EXTRACT} --update --type=gettext/ini
+        --srcdir=${CMAKE_SOURCE_DIR} ${DESKTOP_FILE_IN_IN}
+    
+    COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} -o ${POT_FILE}
+        --from-code=UTF-8
+        --c++ --qt --add-comments=TRANSLATORS
+        --keyword=tr --keyword=tr:1,2 --keyword=N_
+        --package-name='${GALLERY}'
+        --copyright-holder='Canonical Ltd.'
+        -D ${CMAKE_SOURCE_DIR} ${I18N_SRC_FILES}
+        -D ${CMAKE_CURRENT_BINARY_DIR} ${DESKTOP_FILE_IN_IN_H}
+    COMMAND ${CMAKE_COMMAND} -E copy ${POT_FILE} ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(PO_FILE ${PO_FILES})
     get_filename_component(LANG ${PO_FILE} NAME_WE)


### PR DESCRIPTION
At the moment the .pot file is only in the build/ directory after build the app. If you edit something you don't see that the .pot file has changed.

With this we have on every build a new .pot file in directory po/ and the developer can decide if he needs to add the pot file to his commit or is there only the created date changed.
